### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,6 @@
 name: CI/CD for Docker Image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rudrafra772/tms/security/code-scanning/1](https://github.com/rudrafra772/tms/security/code-scanning/1)

To address the issue, the workflow should define a `permissions` key with the least privileges required. Since the workflow only checks out code and pushes to Docker Hub using secrets, it only needs read access to repository contents. Place the following block at the top-level of the workflow (just after `name:` or before `jobs:`), such that all jobs inherit the setting:

```yaml
permissions:
  contents: read
```

No additional changes or dependencies are needed. This restricts the `GITHUB_TOKEN` to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
